### PR TITLE
Add simple AI-based decision helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,7 @@ AI Agent
 
 ## Tic-Tac-Toe Game
 
-<<<<<<< qm1n8z-codex/x-o-x-oyunu-hazırla
-This repository includes a simple Tic-Tac-Toe (XOX) game. A Spring Boot version
-is provided alongside the original Python script.
-=======
 This repository includes a simple Tic-Tac-Toe (XOX) game. A Spring Boot version is provided alongside the original Python script.
->>>>>>> main
 
 ### Running the Spring Boot game
 
@@ -37,12 +32,19 @@ python tic_tac_toe.py
 ```
 
 Follow the on-screen prompts to place your X or O on the board. The game ends when a player wins or the board is full.
-<<<<<<< qm1n8z-codex/x-o-x-oyunu-hazırla
 
 ### Using the web front-end
 
-After starting the Spring Boot application, open `http://localhost:8080/index.html`
-in your browser to play the game with a graphical interface. X markers appear in
-yellow and O markers appear in navy blue.
-=======
->>>>>>> main
+After starting the Spring Boot application, open `http://localhost:8080/index.html` in your browser to play the game with a graphical interface. X markers appear in yellow and O markers appear in navy blue.
+
+## Decision Helper
+
+This repository also includes a small AI-driven decision helper. It relies on a tiny sentiment model to provide clear recommendations for any question.
+
+Run the script with your question:
+
+```bash
+python decision_helper.py "Should I buy a new phone or save my money?"
+```
+
+The helper will reply with a direct recommendation.

--- a/decision_helper.py
+++ b/decision_helper.py
@@ -1,0 +1,50 @@
+import re
+from typing import List
+
+POSITIVE_WORDS: List[str] = [
+    "good", "great", "excellent", "fantastic", "yes", "evet", "love",
+    "olumlu", "harika", "mükemmel", "heyecanlı", "pozitif"
+]
+NEGATIVE_WORDS: List[str] = [
+    "bad", "terrible", "awful", "no", "hayır", "hayir", "hate", "kötü",
+    "negatif", "berbat", "dreadful"
+]
+
+
+def _sentiment_score(text: str) -> int:
+    words = re.findall(r"\w+", text.lower())
+    score = 0
+    for w in words:
+        if w in POSITIVE_WORDS:
+            score += 1
+        if w in NEGATIVE_WORDS:
+            score -= 1
+    return score
+
+
+def make_decision(question: str) -> str:
+    """Return a clear decision derived from a tiny word-based sentiment model."""
+    options = re.split(r"\bor\b|\bveya\b|\bya da\b", question, flags=re.IGNORECASE)
+    cleaned = [opt.strip() for opt in options if opt.strip()]
+    if len(cleaned) >= 2:
+        scores = [_sentiment_score(opt) for opt in cleaned]
+        best_option = cleaned[scores.index(max(scores))]
+        best_option = re.sub(r"^(should|shall)\s+i\s+", "", best_option, flags=re.IGNORECASE)
+        best_option = best_option.strip(" ?!.")
+        return f"Bunu seç: {best_option}"
+    score = _sentiment_score(question)
+    return "EVET, bunu yap." if score >= 0 else "HAYIR, bunu yapma."
+
+
+def main() -> None:
+    import sys
+    if len(sys.argv) > 1:
+        q = " ".join(sys.argv[1:])
+        print(make_decision(q))
+    else:
+        q = input("Sorunuzu yazın: ")
+        print(make_decision(q))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `decision_helper.py` using a tiny sentiment model to recommend a choice
- document the new decision helper in README

## Testing
- `python -m pytest`
- `mvn -q test` *(fails: Could not transfer dependencies, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e426a76d08323be13025289a0d23c